### PR TITLE
Re-use old buffers in new calls

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -1,6 +1,72 @@
 package channels
 
+import (
+	"sort"
+	"sync"
+)
+
 const minQueueLen = 16
+
+type bufCache struct {
+	cache [][]interface{}
+	count int
+	lck   sync.Mutex
+}
+
+var gBufCache = &bufCache{} // global cached buffors
+
+func (bc *bufCache) get(n int) (result []interface{}) {
+	bc.lck.Lock()
+	defer bc.lck.Unlock()
+
+	if n < minQueueLen {
+		n = minQueueLen
+	}
+
+	cacheLen := len(bc.cache)
+	if cacheLen == 0 {
+		bc.count++
+		return make([]interface{}, n)
+	}
+
+	pos := sort.Search(cacheLen, func(x int) bool { return len(bc.cache[x]) >= n })
+	if pos == cacheLen {
+		bc.count++
+		return make([]interface{}, n)
+	}
+
+	result = bc.cache[pos]
+	copy(bc.cache[pos:], bc.cache[pos+1:])
+	bc.cache[cacheLen-1] = nil
+	bc.cache = bc.cache[:cacheLen-1]
+
+	return
+}
+
+func (bc *bufCache) put(buf []interface{}) {
+	bc.lck.Lock()
+	defer bc.lck.Unlock()
+
+	bc.count--
+
+	buf = buf[:cap(buf)]
+	bufLen := len(buf)
+	if bufLen == 0 {
+		return
+	}
+
+	cacheLen := len(bc.cache)
+	pos := sort.Search(cacheLen, func(x int) bool { return len(bc.cache[x]) >= bufLen })
+	bc.cache = append(bc.cache, nil)
+	copy(bc.cache[pos+1:], bc.cache[pos:])
+	bc.cache[pos] = buf
+
+	// if every requested buffer had came back,
+	// assume we do not need cache anymore, flush now
+	if bc.count == 0 && len(bc.cache) > 0 {
+		bc.cache = nil
+	}
+}
 
 // A fast, ring-buffer queue based on the version suggested by Dariusz Górecki.
 // Using this instead of a simple slice+append provides substantial memory and time
@@ -11,7 +77,7 @@ type queue struct {
 }
 
 func newQueue() *queue {
-	return &queue{buf: make([]interface{}, minQueueLen)}
+	return &queue{buf: gBufCache.get(minQueueLen)}
 }
 
 func (q *queue) length() int {
@@ -19,17 +85,18 @@ func (q *queue) length() int {
 }
 
 func (q *queue) resize() {
-	newBuf := make([]interface{}, q.count*2)
+	newBuf := gBufCache.get(q.count * 2)
 
 	if q.tail > q.head {
 		copy(newBuf, q.buf[q.head:q.tail])
-	} else {
+	} else if q.count > 0 {
 		copy(newBuf, q.buf[q.head:len(q.buf)])
 		copy(newBuf[len(q.buf)-q.head:], q.buf[:q.tail])
 	}
 
 	q.head = 0
 	q.tail = q.count
+	gBufCache.put(q.buf)
 	q.buf = newBuf
 }
 


### PR DESCRIPTION
This small change had reduced number of newly allocated buffers during testrun from around 32 to around 10.

Main concerns:
- Some buffers might not get back (go out-of-scope, forgotten), what then?
- Find a sweet-spot when to decide, that we no longer need buffers cache
- Mainly for long-running processes, not so useful for fire&forget

Probably not yet ready to merge, I just want to get someone else thoughts on this
