### PR TITLE
Reduce data loss in overflowing and ring channels.

### DIFF
--- a/overflowing_channel_test.go
+++ b/overflowing_channel_test.go
@@ -8,6 +8,9 @@ func TestOverflowingChannel(t *testing.T) {
 	ch = NewOverflowingChannel(Infinity) // yes this is rather silly, but it should work
 	testChannel(t, "infinite overflowing channel", ch)
 
+	ch = NewOverflowingChannel(1)
+	testChannel(t, "single-element overflowing channel", ch)
+
 	ch = NewOverflowingChannel(10)
 	for i := 0; i < 1000; i++ {
 		ch.In() <- i

--- a/ring_channel_test.go
+++ b/ring_channel_test.go
@@ -8,6 +8,9 @@ func TestRingChannel(t *testing.T) {
 	ch = NewRingChannel(Infinity) // yes this is rather silly, but it should work
 	testChannel(t, "infinite ring-buffer channel", ch)
 
+	ch = NewRingChannel(1)
+	testChannel(t, "single-element ring-buffer channel", ch)
+
 	ch = NewRingChannel(10)
 	for i := 0; i < 1000; i++ {
 		ch.In() <- i


### PR DESCRIPTION
Explicitly prefer to write out old data if available, rather than letting
Golang's scheduler choose whether to read or write. When both directions are
ready, a naive select block chooses randomly, which leads to unnecessary dropped
data 50% of the time.
